### PR TITLE
fixed farming:pumkin and added some more fruits

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -77,8 +77,10 @@ longname = {
 if minetest.get_modpath('default') then
    drinks.juiceable['apple'] = true -- Name of fruit to make juiceable.
    drinks.juiceable['cactus'] = true
+   drinks.juiceable['blueberries'] = true
    table.insert(drinks.drink_table, {'apple', 'Apple', '#ecff56'})
    table.insert(drinks.drink_table, {'cactus', 'Cactus', '#96F97B'})
+   table.insert(drinks.drink_table, {'blueberries', 'Blueberry', '#521dcb'})
 end
 
 if minetest.get_modpath('bushes_classic') then
@@ -136,6 +138,9 @@ if minetest.get_modpath('farming') then
    drinks.juiceable['pumpkin_slice'] = true
    drinks.juiceable['raspberries'] = true
    drinks.juiceable['rhubarb'] = true
+   drinks.juiceable['blueberries'] = true
+   drinks.juiceable['pineapple'] = true
+   drinks.juiceable['pineapple_ring'] = true
    table.insert(drinks.drink_table, {'melon', 'Melon', '#ef4646'})
    table.insert(drinks.drink_table, {'tomato', 'Tomato', '#990000'})
    table.insert(drinks.drink_table, {'carrot', 'Carrot', '#ed9121'})
@@ -144,6 +149,8 @@ if minetest.get_modpath('farming') then
    table.insert(drinks.drink_table, {'pumpkin', 'Pumpkin', '#ffc04c'})
    table.insert(drinks.drink_table, {'raspberries', 'Raspberry', '#C70039'})
    table.insert(drinks.drink_table, {'rhubarb', 'Rhubarb', '#fb8461'})
+   table.insert(drinks.drink_table, {'blueberries', 'Blueberry', '#521dcb'})
+   table.insert(drinks.drink_table, {'pineapple', 'Pineapple', '#dcd611'})
 end
 
 if minetest.get_modpath('fruit') then

--- a/init.lua
+++ b/init.lua
@@ -151,6 +151,8 @@ if minetest.get_modpath('farming') then
    table.insert(drinks.drink_table, {'rhubarb', 'Rhubarb', '#fb8461'})
    table.insert(drinks.drink_table, {'blueberries', 'Blueberry', '#521dcb'})
    table.insert(drinks.drink_table, {'pineapple', 'Pineapple', '#dcd611'})
+   minetest.register_alias_force('farming:carrot_juice', 'drinks:jcu_carrot')
+   minetest.register_alias_force('farming:pineapple_juice', 'drinks:jcu_pineapple')
 end
 
 if minetest.get_modpath('fruit') then

--- a/init.lua
+++ b/init.lua
@@ -132,7 +132,8 @@ if minetest.get_modpath('farming') then
    drinks.juiceable['carrot'] = true
    drinks.juiceable['cucumber'] = true
    drinks.juiceable['grapes'] = true
-   drinks.juiceable['pumpkin'] = true
+   drinks.juiceable['pumpkin_8'] = true
+   drinks.juiceable['pumpkin_slice'] = true
    drinks.juiceable['raspberries'] = true
    drinks.juiceable['rhubarb'] = true
    table.insert(drinks.drink_table, {'melon', 'Melon', '#ef4646'})
@@ -159,6 +160,7 @@ end
 if minetest.get_modpath('ethereal') then
    drinks.juiceable['banana'] = true
    drinks.juiceable['coconut'] = true
+   drinks.juiceable['coconut_slice'] = true
    drinks.juiceable['orange'] = true
    drinks.juiceable['strawberry'] = true
    table.insert(drinks.drink_table, {'banana', 'Banana', '#eced9f'})


### PR DESCRIPTION
The pumpkin and the coconut slices of the farming mod did not work on our server, so I fixed this by changing / adding `pumpkin_8`, `pumpkin_slice` and `coconut_slice`.

Pineapple Juice (farming mod) and Blueberry Juice (default and farming mod) was missing, so I added it.

I also added aliases for `farming:carrot_juice` and `farming:pineapple_juice`.

Thanks for this great mod.